### PR TITLE
TGC-1459: Prepare repository for AI assistance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ coverage
 allure-report/
 allure-results/
 FAILED
+AGENTS.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+This repository contains WebdriverIO end-to-end tests for SFI reform service journeys. Test specs live in `test/specs/`, page objects in `test/page-objects/`, and reusable helpers/API clients in `test/utils/`. Root WDIO configs select the execution target: `wdio.conf.js`, `wdio.local.conf.js`, and `wdio.github.conf.js`. Docker and CI support files are in `Dockerfile`, `compose.yml`, `docker/`, `.github/workflows/`, `entrypoint.sh`, and `run-journey-tests/`. Allure report output is generated into `allure-results/` and `allure-report/`.
+
+## Build, Test, and Development Commands
+
+- `npm install`: install dependencies and set up Husky hooks.
+- `npm run test`: clean reports, then run WDIO using `wdio.conf.js`.
+- `npm run test:local`: run tests against the local `baseUrl` in `wdio.local.conf.js`.
+- `npm run test:local:debug`: run local tests with `DEBUG=true`.
+- `npm run test:github`: run the GitHub-oriented WDIO config.
+- `npm run lint` / `npm run lint:fix`: check or fix ESLint issues.
+- `npm run format:check` / `npm run format`: check or apply Prettier formatting.
+- `npm run report`: generate a single-file Allure report from `allure-results/`.
+
+## Coding Style & Naming Conventions
+
+Use Node.js `>=20.11.1` and ES modules. Formatting follows `.editorconfig` and Prettier: 2-space indentation, LF endings, no semicolons, single quotes, and no trailing commas. ESLint extends Standard, Prettier, recommended JavaScript rules, and WDIO recommendations. Keep page objects named by page or journey, for example `cw.tasks.page.js`; keep specs descriptive and journey-oriented, for example `single_action_journey.js`.
+
+## Testing Guidelines
+
+Tests use WebdriverIO with the Mocha framework and WDIO globals. Prefer shared page objects and helper modules over duplicating browser/API setup in specs. Run `npm run lint` and the relevant WDIO command before opening a PR. When debugging locally, ensure the target service is running at the `baseUrl` configured in `wdio.local.conf.js`.
+
+## Domain Language
+
+Use `CONTEXT.md` as the source of truth for grant, land action, casework, agreement, and journey-test language. When adding specs, page objects, helpers, or generated docs, prefer the glossary terms there and avoid synonyms that obscure the business flow.
+
+## Developer Addenda
+
+Developers can add their own `AGENTS.local.md` and should be read as an addendum to this file. Keep that file local to your machine and do not commit it.
+
+## Commit & Pull Request Guidelines
+
+Recent history uses short, imperative or descriptive commit subjects, often tied to a feature branch or merge PR, for example `Clear grant version specific state`. Keep commits focused. PRs should explain the journey or environment affected, list the test command run, link any relevant issue, and include report or screenshot evidence when browser behaviour changes.
+
+## Security & Configuration Tips
+
+Use `.env.example` and `docker/config/*.env` as templates; do not commit real secrets or environment-specific credentials. Generated report directories should remain disposable.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,53 @@
+# sfi-reform-service-e2e-tests
+
+End-to-end WebdriverIO coverage for land grants, woodland journeys, casework, and agreement lifecycle flows.
+
+## Language
+
+**Grant journey**
+The user-facing application flow under test, from sign-in through answers, review, declaration, submission, and post-submission states.
+_Avoid_: Wizard, Survey, Script
+
+**Land action**
+A configured environmental action selected by the applicant, such as `CLIG3` or `UPL8`, that drives eligibility, payment, and agreement behaviour.
+_Avoid_: Product, Item, Option
+
+**Land parcel**
+A registered area of land associated with an SBI and selected for one or more actions.
+_Avoid_: Field, Plot, Property
+
+**Consent**
+Evidence or confirmation needed before an action can proceed, such as HEFER or SSSI consent.
+_Avoid_: Permission when referring to the configured journey requirement, Approval unless it is the official state
+
+**Agreement**
+The downstream arrangement reached after an application has an offer and the user accepts it.
+_Avoid_: Application, Declaration, Contract when unspecified
+
+**Offer**
+The proposal presented for review before an agreement is accepted, terminated, or otherwise acted on.
+_Avoid_: Quote, Contract, Confirmation
+
+**Casework**
+The internal case-management view used to inspect applications, tasks, timelines, and statuses.
+_Avoid_: Admin UI, Back office when a specific casework page is meant
+
+**Task**
+A casework or journey unit of work whose completion affects progress through the application or agreement lifecycle.
+_Avoid_: Page, Step, Section
+
+**GAS**
+The Grants Application Service used for submission and lifecycle state.
+_Avoid_: Grants UI Backend, Casework, GPS
+
+**GPS**
+The Grant Payments Service used by tests that verify payment-related behaviour.
+_Avoid_: GAS, Payment page, Finance system
+
+**CRN**
+Customer Reference Number: the Defra ID identifier for an individual user.
+_Avoid_: SBI, User ID, Account number
+
+**SBI**
+Single Business Identifier: the farm business or organisation represented by the signed-in user.
+_Avoid_: CRN, Business name, Holding number


### PR DESCRIPTION
## Summary

- Add repository guidance for AI coding agents in `AGENTS.md`.
- Add `CONTEXT.md` as the source of truth for domain language where needed.
- Ignore local-only `AGENTS.local.md` addenda without creating that file.
